### PR TITLE
Release v3.0.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
-  schedule:
-    - cron: '30 08 * * 5'
+  # schedule:
+  #   - cron: '30 08 * * 5'
 
 jobs:
   analyze:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ on:
     # branches-ignore: [main]
     # Remove the line above to run when pushing to master
   pull_request:
-    branches: [main]
+    branches: [main, release]
 
 ###############
 # Set the Job #

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # clasp-related files
 .clasp.json
+memo.clasp.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+https://www.scriptable-assets.page/terms-and-conditions/#contact.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/appsscript.json
+++ b/appsscript.json
@@ -8,6 +8,7 @@
     "https://www.googleapis.com/auth/gmail.compose",
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/script.locale",
+    "https://www.googleapis.com/auth/script.send_mail",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/userinfo.email"
   ],

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,16 +16,24 @@
 
 /* exported LocalizedMessage  */
 
+// Message Naming Rules:
+// Name of the message (key) must start with 'error' for error messages
+// to distinguish between expected and unexpected errors
+
 const MESSAGES = {
   'en': {
-    'cardMessage': '<b>Group Merge: Mail Merge for Gmail</b>\nOpen-sourced add-on to send personalized emails based on Gmail template to multiple recipients. The unique <b>Group Merge</b> feature allows sender to group multiple contents for the same recipient in a single email.\n\nEnter the following items and select <b><i>Create Drafts</i></b> or <b><i>Send Emails</i></b>. <b>All items are required fields</b> unless otherwise noted.',
+    'cardHomepageMessage': '<b>Group Merge: Mail Merge for Gmail</b>\nOpen-sourced add-on to send personalized emails based on Gmail template to multiple recipients. The unique <b>Group Merge</b> feature allows sender to group multiple contents for the same recipient in a single email.\n\nEnter the following items and select <b><i>Create Drafts</i></b> or <b><i>Send Emails</i></b>. <b>All items are required fields</b> unless otherwise noted.',
     'cardRecipientListSettings': '1. Recipient List',
     'cardEnterSpreadsheetUrl': 'Spreadsheet URL',
     'cardHintSpreadsheetUrl': 'Enter the full URL of the Google Sheets spreadsheet used as the list of recipients.',
     'cardEnterSheetName': 'Sheet Name',
     'cardHintSheetName': 'Name of the worksheet of the recipient list. Make sure that the first row of this sheet is used for merge field names.',
-    'cardEnterRecipientColName': 'Recipient Field (column) Name',
-    'cardHintRecipientColName': 'Field (column) name that lists the recipient\'s email address.',
+    'cardEnterTo': 'To',
+    'cardHintTo': 'Recipient\'s email address. Use field markers for only one address, e.g. {{Email}}. If you want to send the respective personalized mails to more than one account, make use of the CC and BCC fields.',
+    'cardEnterCc': 'CC',
+    'cardHintCc': '[Optional] CC recipients\' email address. Use commas to seperate multiple addresses.',
+    'cardEnterBcc': 'BCC',
+    'cardHintBcc': '[Optional] BCC recipients\' email address. Use commas to seperate multiple addresses.',
     'cardTemplateDraftSettings': '2. Template Draft',
     'cardEnterTemplateSubject': 'Subject of Template Draft Mail',
     'cardHintTemplateSubject': 'Be sure to make the template subject unique; an error will be returned if there are two or more draft messages with the same subject.',
@@ -37,14 +45,19 @@ const MESSAGES = {
     'cardEnterReplaceValue': 'Replace Value',
     'cardHintReplaceValue': 'Text that will replace markers with empty data.',
     'cardEnterMergeFieldMarker': 'Merge Field Marker',
-    'cardHintMergeFieldMarker': 'Text to be processed in RegExp() constructor to define merge field(s). Note that the backslash itself does not need to be escaped, i.e., does not need to be repeated.',
+    'cardHintMergeFieldMarker': 'Text to be processed in RegExp() constructor to define merge field(s). Be sure to use parentheses to denote the capturing group to mark the content of the field, i.e., the word "field" in {{field}}. Note that the backslash itself does not need to be escaped.',
     'cardEnterGroupFieldMarker': 'Group Field Marker',
-    'cardHintGroupFieldMarker': 'Text to be processed in RegExp() constructor to define group merge field(s). Note that the backslash itself does not need to be escaped, i.e., does not need to be repeated.',
+    'cardHintGroupFieldMarker': 'Text to be processed in RegExp() constructor to define group merge field(s). Be sure to use parentheses to denote the capturing group to mark the content of the field. Note that the backslash itself does not need to be escaped.',
     'cardEnterRowIndexMarker': 'Row Index Marker',
     'cardHintRowIndexMarker': 'Marker for merging row index number in a group merge.',
+    'cardSwitchEnableDebugMode': 'Enable debug mode',
+    'cardMessageUnexpectedError': 'Unexpected Error:\n',
+    'cardMessageDebugInfo': 'Debug Info\nBe careful to exclude any sensitive information, like your clients\' email addresses, if you are going to copy & paste the below debug information elsewhere:\n\n',
+    'cardMessageSentDebugInfo': '<b>Email of the debug info is sent to your Gmail account.</b>',
     'buttonRestoreUserConfig': 'Restore User Settings',
     'buttonRestoreDefault': 'Restore Default Settings',
-    'buttonReadDocument': 'Read Document',
+    'buttonReadDocument': 'Website',
+    'buttonReadDocumentUrl': 'https://www.scriptable-assets.page/add-ons/group-merge/',
     'buttonSaveUserConfig': 'Save User Settings',
     'buttonCreateDrafts': 'Create Drafts',
     'buttonSendDrafts': 'Send Created Drafts',
@@ -55,26 +68,36 @@ const MESSAGES = {
     'alertConfirmAccountCreateDraft': 'Are you sure you want to create draft email(s) as {{myEmail}}?',
     'alertConfirmAccountSendEmail': 'Are you sure you want to send email(s) as {{myEmail}}?',
     'errorMailMergeCanceled': 'Mail merge canceled.',
-    'errorNoTextEntered': '[Mail Merge Error]\nEnter the subject of the Gmail draft message to use as template for mail merge.',
+    'errorNoSubjectTextEntered': '[Mail Merge Error]\nEnter the subject of the Gmail draft message to use as template for mail merge.',
     'errorTwoOrMoreDraftsWithSameSubject': '[Mail Merge Error]\nThere are 2 or more Gmail drafts with the subject you entered. Enter a unique subject text.',
     'errorNoMatchingTemplateDraft': '[Mail Merge Error]\nNo template Gmail draft message with matching subject found. Make sure the subject that you entered is correct.',
-    'errorInvalidRECIPIENT_COL_NAME': '[Mail Merge Error]\nInvalid Recipient Field (column) Name. Make sure this value refers to an existing column name.',
-    'alertCompleteAllDraftsCreated': 'Complete: {{messageCount}} draft(s) created.',
+    'errorNoToEntered': '[Mail Merge Error]\nNo To recipients entered. Make sure you have entered the placeholder value of the email address to use as To.',
+    'errorMultipleToEntered': '[Mail Merge Error]\nThere are multiple To\'s entered as merge fields. Use only one.',
+    'errorInvalidTo': '[Mail Merge Error]\nInvalid Recipient Field (column) Name. Make sure the placeholder value in "To" refers to an existing column name.',
+    'alertCompleteAllDraftsCreated': 'Complete: {{messageCount}} draft(s) created. Reload Gmail\'s Drafts page if you are not seeing the full drafted list of merged mails.',
     'alertCompleteAllMailsSent': 'Complete: {{messageCount}} mail(s) sent.',
     'alertConfirmSendingOfDraft': 'Are you sure you want to send the draft email(s) as {{myEmail}}?\nOnly the drafts created by "Create Drafts" will be sent.',
     'errorSendDraftsCanceled': 'Sending drafts is canceled.',
     'errorNoDraftToSend': '[Mail Merge Error]\nNo draft found. Execute "Create Drafts" to create merged drafts.',
-    'alertCompleteSavedUserConfig': 'Complete: Saved user settings.\n\n'
+    'alertCompleteSavedUserConfig': 'Complete: Saved user settings.\n\n',
+    'appsScriptMessageErrorOnOpenByUrlStartsWith': 'Unexpected error while getting the method or property openByUrl',
+    'appsScriptMessageNoPermissionErrorStartsWith': 'You do not have permission to access the requested document.',
+    'proceedingToPostProcess': 'Since the current mail merge process is expected to exceed the {{actionLimitTimeInSec}}-second execution time limit, the remaining process will be conducted on a time-based trigger. A mail report will be sent to {{myEmail}} once the whole process is complete.\nDraft Mode: {{draftMode}}\nMessage Count: {{messageCount}}',
+    'subjectPostProcessUpdate': '[GROUP MERGE] Mail Merge Notice'
   },
   'ja': {
-    'cardMessage': '<b>Group Merge: Mail Merge for Gmail</b>\nオープンソースで利用可能なGmailのための差し込みメール作成用アドオン。同じ宛先への複数行にわたる情報を1通のメールにまとめられる<b>まとめ差し込み（Group Merge）</b>機能付き。\n\n以下の項目を入力して「<b>テスト差込（下書きメール作成）</b>」または「<b>差込み送信（メール送信）</b>」を選択してください。\n別途説明がある項目を除けば<b>すべて必須の入力項目</b>です。',
+    'cardHomepageMessage': '<b>Group Merge: Mail Merge for Gmail</b>\nオープンソースで利用可能なGmailのための差し込みメール作成用アドオン。同じ宛先への複数行にわたる情報を1通のメールにまとめられる<b>まとめ差し込み（Group Merge）</b>機能付き。\n\n以下の項目を入力して「<b>テスト差込（下書きメール作成）</b>」または「<b>差込み送信（メール送信）</b>」を選択してください。\n別途説明がある項目を除けば<b>すべて必須の入力項目</b>です。',
     'cardRecipientListSettings': '1. 宛先リストの設定',
     'cardEnterSpreadsheetUrl': 'スプレッドシートURL',
     'cardHintSpreadsheetUrl': '宛先リストのスプレッドシートURLを入力',
     'cardEnterSheetName': 'シート名',
     'cardHintSheetName': '宛先リストが記載されているシートの名前。1行目が差込フィールド名となっていることをご確認ください。',
-    'cardEnterRecipientColName': '宛先メールアドレスの列名',
-    'cardHintRecipientColName': '宛先となるメールアドレスが記載されているフィールド（列）の名前',
+    'cardEnterTo': '宛先メールアドレス',
+    'cardHintTo': 'Toとして登録する宛先メールアドレス。必ず差し込みフィールドを1つだけ使ってください（例：{{Email}}）。複数の宛先に同時に送りたい場合は、CCやBCC欄をご活用ください。',
+    'cardEnterCc': 'CC',
+    'cardHintCc': '[オプション] CCとして登録するメールアドレス。差し込みフィールド使用可。カンマ区切りで複数宛先を登録可。（例：{{cc}}},{{anotherCc}},fixedEmail@sample.com）',
+    'cardEnterBcc': 'BCC',
+    'cardHintBcc': '[オプション] BCCとして登録するメールアドレス。差し込みフィールド使用可。カンマ区切りで複数宛先を登録可。（例：{{bcc}},{{anotherBcc}},fixedEmail@sample.com）',
     'cardTemplateDraftSettings': '2. テンプレートの設定',
     'cardEnterTemplateSubject': 'テンプレートとなる下書きメールの件名',
     'cardHintTemplateSubject': 'テンプレートとなる下書きメールの件名に重複がないようご注意ください。入力した件名を持つ下書きメールが2通以上ある場合、エラーとなります。',
@@ -82,18 +105,23 @@ const MESSAGES = {
     'cardAdvancedSettings': '3. 高度な設定',
     'cardSwitchEnableReplyTo': 'Reply-To設定を有効にする',
     'cardEnterReplyTo': 'Reply-Toメールアドレス',
-    'cardHintReplyTo': '[Reply-To設定が有効の場合にのみ入力必須] Reply-Toとして設定するメールアドレス。ここでも差し込みフィールドを使うことができる（例：{{replyTo}}@mydomain.com や {{replyToAddress}}',
+    'cardHintReplyTo': '[Reply-To設定が有効の場合にのみ入力必須] Reply-Toとして設定するメールアドレス。ここでも差し込みフィールドを使うことができる（例：{{replyTo}}@mydomain.com や {{replyToAddress}}）',
     'cardEnterReplaceValue': 'データ不在時の差し込みテキスト',
     'cardHintReplaceValue': '該当するデータがない場合に差し込まれる文字列',
     'cardEnterMergeFieldMarker': '差し込みフィールドのマーカー',
-    'cardHintMergeFieldMarker': '差し込みフィールドを定義する正規表現。バックスラッシュ（\\）自体はエスケープ不要。',
+    'cardHintMergeFieldMarker': '差し込みフィールドを定義する正規表現。フィールド名そのもの（例：{{名前}}の中の「名前」という文字列）を検出するためのキャプチャグループ（"( )"）を使用すること。バックスラッシュ（\\）自体はエスケープ不要。',
     'cardEnterGroupFieldMarker': 'まとめ差し込みフィールドのマーカー',
-    'cardHintGroupFieldMarker': 'まとめ差し込みフィールドを定義する正規表現。バックスラッシュ（\\）自体はエスケープ不要。',
+    'cardHintGroupFieldMarker': 'まとめ差し込みフィールドを定義する正規表現。フィールド名そのもの（例：[[ミーティング{{i}}]]の中の「ミーティング{{i}}」という文字列）を検出するためのキャプチャグループ（"( )"）を使用すること。バックスラッシュ（\\）自体はエスケープ不要。',
     'cardEnterRowIndexMarker': 'まとめ差し込み番号マーカー',
     'cardHintRowIndexMarker': 'まとめ差し込みで、同一宛先内の差し込み順序を番号付けするためのマーカー',
+    'cardSwitchEnableDebugMode': 'デバッグモードを有効にする',
+    'cardMessageUnexpectedError': '予期しないエラー：\n',
+    'cardMessageDebugInfo': 'デバッグ情報\n以下のデバッグ情報をどこかにコピー＆ペーストする際は、顧客のメールアドレスなどの機密情報を取り除くよう注意してください：\n\n',
+    'cardMessageSentDebugInfo': '<b>デバッグ情報がメールにてお使いのGoogleアカウントに送信されました。</b>',
     'buttonRestoreUserConfig': '保存した設定を使用',
     'buttonRestoreDefault': '初期設定に戻す',
-    'buttonReadDocument': '説明を読む',
+    'buttonReadDocument': 'ウェブサイトへ',
+    'buttonReadDocumentUrl': 'https://www.scriptable-assets.page/ja/add-ons/group-merge/',
     'buttonSaveUserConfig': 'ユーザ設定として保存',
     'buttonCreateDrafts': '下書き作成（差込テスト）',
     'buttonSendDrafts': '作成済みの下書きを送信',
@@ -104,16 +132,22 @@ const MESSAGES = {
     'alertConfirmAccountCreateDraft': '{{myEmail}}として差し込みメールを作成し、下書きとして保存します。',
     'alertConfirmAccountSendEmail': '{{myEmail}}として差し込みメールを作成し、送信します。',
     'errorMailMergeCanceled': 'メールの差し込みが中断されました。',
-    'errorNoTextEntered': '[Mail Merge Error]\nテンプレートとなるGmail下書きメッセージの件名が入力されていません。',
+    'errorNoSubjectTextEntered': '[Mail Merge Error]\nテンプレートとなるGmail下書きメッセージの件名が入力されていません。',
     'errorTwoOrMoreDraftsWithSameSubject': '[Mail Merge Error]\n入力された件名を持つ下書きメッセージが2件以上あります。固有の件名で指定してください。',
     'errorNoMatchingTemplateDraft': '[Mail Merge Error]\n入力された件名を持つ下書きメッセージが見つかりません。件名が正しく入力されていることを確認してください。',
-    'errorInvalidRECIPIENT_COL_NAME': '[Mail Merge Error]\n入力された宛先メールアドレスの列（フィールド）名が無効です。実際に存在するフィールド（列）が指定されていることを確認してください。',
-    'alertCompleteAllDraftsCreated': '完了：{{messageCount}}通の下書きが作成されました。',
+    'errorNoToEntered': '[Mail Merge Error]\nToとして使用する宛先メールアドレスが空白です。メールアドレスとなる文字列や差し込みフィールドが入力されていることを確認してください。',
+    'errorMultipleToEntered': '[Mail Merge Error]\nToとして複数の宛先メールアドレスの差し込みフィールドが入力されています。差し込みフィールドとして使える宛先メールアドレスは1つのみです。',
+    'errorInvalidTo': '[Mail Merge Error]\n入力された宛先メールアドレスの列（フィールド）名が無効です。実際に存在するフィールド（列）が指定されていることを確認してください。',
+    'alertCompleteAllDraftsCreated': '完了：{{messageCount}}通の下書きが作成されました。差し込み済みのメールが表示されない場合、Gmailの下書き画面を更新してください。',
     'alertCompleteAllMailsSent': '完了：{{messageCount}}通の差し込みメールの送信が完了しました。',
     'alertConfirmSendingOfDraft': '{{myEmail}}として、作成された下書きメールを送信してもよろしいですか？\n「下書き作成（差込テスト）」によって作成された下書きのみが送信されます。',
     'errorSendDraftsCanceled': '下書きメールの送信がキャンセルされました。',
     'errorNoDraftToSend': '[Mail Merge Error]\n送信する下書きメールが見つかりません。改めて「下書き作成（差込テスト）」を行ってください。',
-    'alertCompleteSavedUserConfig': '完了：ユーザ設定として現在の設定が保存されました。\n\n'
+    'alertCompleteSavedUserConfig': '完了：ユーザ設定として現在の設定が保存されました。\n\n',
+    'appsScriptMessageErrorOnOpenByUrl': 'SpreadsheetApp オブジェクトでの openByUrl メソッドまたはプロパティの取得中に予期しないエラーが発生',
+    'appsScriptMessageNoPermissionErrorStartsWith': 'リクエストされたドキュメントにアクセスする権限がありません。',
+    'proceedingToPostProcess': '現在の処理はGoogle Workspaceアドオンに設けられた{{actionLimitTimeInSec}}秒の実行時間制限を超過する見込みです。残りの差し込み処理はトリガーによって自動的に実行され、完了は{{myEmail}}宛のメールで通知されます。\n下書きモード：{{draftMode}}\n現在までに完了したメッセージ数：{{messageCount}}',
+    'subjectCompletePostProcess': '[GROUP MERGE] 差し込み処理のお知らせ'
   }
 };
 
@@ -180,6 +214,37 @@ class LocalizedMessage {
   replaceCompleteMessage(draftMode, messageCount) {
     let text = (draftMode ? this.messageList.alertCompleteAllDraftsCreated : this.messageList.alertCompleteAllMailsSent);
     let placeholderValues = [
+      {
+        'regexp': '\{\{messageCount\}\}',
+        'value': messageCount
+      }
+    ];
+    text = this.replacePlaceholders_(text, placeholderValues);
+    return text;
+  }
+  /**
+   * Replace placeholder string in this.messageList.proceedingToPostProcess
+   * @param {number} actionLimitTimeInSec
+   * @param {string} myEmail
+   * @param {boolean} draftMode
+   * @param {number} messageCount Number of emails drafted or sent
+   * @returns {string} The replaced text.
+   */
+  replaceProceedingToPostProcess(actionLimitTimeInSec, myEmail, draftMode, messageCount) {
+    let text = this.messageList.proceedingToPostProcess;
+    let placeholderValues = [
+      {
+        'regexp': '\{\{actionLimitTimeInSec\}\}',
+        'value': actionLimitTimeInSec
+      },
+      {
+        'regexp': '\{\{myEmail\}\}',
+        'value': myEmail
+      },
+      {
+        'regexp': '\{\{draftMode\}\}',
+        'value': draftMode
+      },
       {
         'regexp': '\{\{messageCount\}\}',
         'value': messageCount


### PR DESCRIPTION
- Resolve #49 : CC and BCC recipients can now be personalized via the add-on side panel. Use placeholders to designate them: e.g., {{cc}} and {{bcc}}
- Resolve #60 : Debug mode is now available at the bottom-most part of the Advanced Settings section in the add-on side panel. When enabled, details of the settings and a simple & personal log for each action is sent to the user in form of an email. This feature utilizes the Apps Script method `MailApp.sendEmail()`, which requires an addition to the OAuth scope that the add-on requests from the user: `https://www.googleapis.com/auth/script.send_mail` = `Send email as you`, or in Japanese, `ユーザー本人に代わってのメールの送信`
- Resolve #62 : This is the biggest update from v2; because there is a 30-second limit to the Card Service actions in Google Workspace Add-ons, an `Exceeded maximum execution time` was returned for a recipient list of approx. 50 or more rows. To work around this issue, a time-based triggering of a post-process function has been implemented. Note that there are still some issues left at #68 
- Resolve #69 : Subsequent to the changes addressing #62, the draft ID of the template Gmail draft is now carried over to the post-process to avoid merged mails to be falsely recognized as template drafts having non-unique subjects.