### PR TITLE
Issues resolved for v3.0.1

### DIFF
--- a/src/mailMerge.js
+++ b/src/mailMerge.js
@@ -312,9 +312,11 @@ function sendDrafts(event) {
       throw new Error(localizedMessage.messageList.errorNoDraftToSend);
     }
     // Send emails
-    createdDraftIds.forEach(draftId => {
-      GmailApp.getDraft(draftId).send();
-      messageCount += 1;
+    GmailApp.getDrafts().forEach(draft => {
+      if (createdDraftIds.includes(draft.getId())) {
+        draft.send();
+        messageCount += 1;
+      }
     });
     // Empty createdDraftIds
     createdDraftIds = [];

--- a/src/mailMerge.js
+++ b/src/mailMerge.js
@@ -453,9 +453,7 @@ function mailMerge(draftMode = true, config = DEFAULT_CONFIG, prevProperties = {
       throw new Error(localizedMessage.messageList.errorNoMatchingTemplateDraft);
     }
     // Store template into an object
-    let messageTo = draftMessages[0].getTo();
-    let messageCc = draftMessages[0].getCc();
-    let messageBcc = draftMessages[0].getBcc();
+    let [messageTo, messageCc, messageBcc] = [draftMessages[0].getTo(), draftMessages[0].getCc(), draftMessages[0].getBcc()];
     let template = {
       'subject': config.TEMPLATE_SUBJECT,
       'plainBody': draftMessages[0].getPlainBody(),
@@ -469,6 +467,9 @@ function mailMerge(draftMode = true, config = DEFAULT_CONFIG, prevProperties = {
       'labels': draftMessages[0].getThread().getLabels(),
       'replyTo': (config.ENABLE_REPLY_TO ? config.REPLY_TO : '')
     };
+    template.to = (template.to.slice(0, 1) === ',' ? template.to.slice(1) : template.to);
+    template.cc = (template.cc.slice(0, 1) === ',' ? template.cc.slice(1) : template.cc);
+    template.bcc = (template.bcc.slice(0, 1) === ',' ? template.bcc.slice(1) : template.bcc);
     debugInfo.processTime.push(`Retrieved template draft data at ${(new Date()).getTime() - debugInfo.start} (millisec from start)`);
     // Check template format; plain or HTML text.
     let isPlainText = (template.plainBody === template.htmlBody);


### PR DESCRIPTION
- Resolved #66: Behind the `SEND CREATED DRAFTS` button was a function to send the set of drafted Gmails created by the mail merge process by [designating the respective draft IDs](https://developers.google.com/apps-script/reference/gmail/gmail-app?hl=en#getDraft(String)) and [sending the draft object](https://developers.google.com/apps-script/reference/gmail/gmail-draft?hl=en#send()) (`GmailApp.getDraft(draftID).send()`). This process, however, resulted in an error and termination of the whole process if any of the draft IDs returned an error, i.e., if the draft was not found when searched by its draft ID. Now, since the revised process goes over the whole drafts in the account and checking them to see if its draft ID matches with any of the created draft IDs, this termination can be avoided.
- Resolved #73: When the user entered fixed email address(es) in CC and/or BCC recipient in the draft template, an `Invalid Email` error was returned. This is now fixed.