### PR TITLE
Bump Super Linter from v3 to v4

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,8 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        # uses: github/super-linter@v4
+        uses: docker://ghcr.io/github/super-linter:slim-v4 # See https://github.com/github/super-linter#images
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_ES: true


### PR DESCRIPTION
Use slim-v4 image. See https://github.com/github/super-linter#slim-image for details.