### PR TITLE
Bump Node version in GitHub Workflows with `with.node-version` to `22` in `actions/setup-node`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Cache node modules
         uses: actions/cache@v3.3.2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Cache node modules
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Resolve #382 

This pull request includes updates to the Node.js version used in the GitHub Actions workflows for deployment and linting.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L26-R26): Updated the Node.js version from 16 to 22.
* [`.github/workflows/linter.yml`](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L29-R29): Updated the Node.js version from 20 to 22.